### PR TITLE
Update learning.md

### DIFF
--- a/mkdocs/docs/community/learning.md
+++ b/mkdocs/docs/community/learning.md
@@ -13,3 +13,6 @@ To complete...
 ##  Johannes Gutenberg University of Mainz
 
 To complete...
+
+## Université Paris 8
+A 24 hours introduction to Faust is given by Alain Bonardi during the first semester to undergraduated students (L3, 3rd year after the french 'baccalauréat') in the framework of the course "Programming Languages in Computer Music 1" offered in the "Music creation with computers" minor.


### PR DESCRIPTION
## Université Paris 8
A 24 hours introduction to Faust is given by Alain Bonardi during the first semester to undergraduated students (L3, 3rd year after the french 'baccalauréat') in the framework of the course "Programming Languages in Computer Music 1" offered in the "Music creation with computers" minor.