### PR TITLE
Updated to mkdocs 1.5.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ $(DSTARCH):
 
 ####################################################################
 install:
-	pip install mkdocs
+	pip install mkdocs==1.5.3
 	pip install mkdocs-pdf-export-plugin
 	pip install markdown-include
 	pip install mkdocs-bootswatch

--- a/mkdocs/theme/base.html
+++ b/mkdocs/theme/base.html
@@ -30,7 +30,7 @@
 
       {%- block libs %}
 
-        <script src="{{ 'js/jquery-1.10.2.min.js'|url }}" defer></script>
+        <script src="{{ 'js/jquery-3.6.0.min.js'|url }}" defer></script>
         <script src="{{ 'js/bootstrap.min.js'|url }}" defer></script>
         {%- if config.theme.highlightjs %}
         <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>


### PR DESCRIPTION
Updated Makefile to force mkdocs to a fixed version. 
Updated mkdocs/theme/base.html to use jquery-3.6.0.min.js as provided by mkdocs 1.5.3

This prevents numerous errors caused by significant changes in newer mkdocs versions.